### PR TITLE
Replaced deprecated Vec4f0/Point2f0 with Vec4f/Point2f, suppressed ea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ ENV["QSG_RENDER_LOOP"] = "basic"
 ```
 on top of most scripts to disable QML multithreading which is not yet supported by QML 0.9.
 
+### Notes
+- `Makie v0.17.13` is required for plots using that library.
+
 ### Basic examples
 - board  OK
 - canvas OK

--- a/opengl/makie-plot.jl
+++ b/opengl/makie-plot.jl
@@ -11,11 +11,11 @@ using GeometryBasics
 const xpos = Observable(collect(0.1:0.05:0.3))
 const ypos = Observable(rand(length(xpos[])))
 
-fig, ax, pl = lines(xpos, ypos, color = :blue)
-autolimits!(ax)
+fig, ax, pl = lines(xpos, ypos, color = :blue);
+autolimits!(ax);
 
-figscene = fig.scene
-axscene = ax.scene
+figscene = fig.scene;
+axscene = ax.scene;
 
 const needupdate = Observable(true)
 
@@ -31,7 +31,7 @@ function to_screen(scene, point)
   plotrect = pixelarea(scene)[]
   cam_res = widths(plotrect)
   prj_view = cam.projection[] * cam.view[] * Makie.transformationmatrix(scene)[]
-  pix_space = prj_view * Vec4f0(point[1], point[2], 0.0, 1.0)
+  pix_space = prj_view * Vec4f(point[1], point[2], 0.0, 1.0)
   clip_space = (pix_space[1], pix_space[2])
   return ((clip_space .+ 1) ./ 2) .* cam_res .+ Makie.origin(plotrect)
 end
@@ -58,7 +58,7 @@ function setpos(lm, x_or_y, listidx, i)
 end
 
 function setscreenpos(lm, x_or_y, listidx, i)
-  axscreenpos = Point2f0(x_or_y, x_or_y) .- Makie.origin(pixelarea(axscene)[])
+  axscreenpos = Point2f(x_or_y, x_or_y) .- Makie.origin(pixelarea(axscene)[])
   setpos(lm, to_world(axscene, axscreenpos)[i], listidx, i)
 end
 


### PR DESCRIPTION
Fixed some issues mentioned here:
https://discourse.julialang.org/t/qml-jl-makie-plot-example-gives-multiple-errors/128444/11

Ie: Replaced deprecated `Vec4f0`/`Point2f0` with `Vec4f`/`Point2f`, suppressed early plotting in case run in `REPL`, put `Makie` version note in readme.